### PR TITLE
swap the order of the display formatters

### DIFF
--- a/ipywidgets/interact.py
+++ b/ipywidgets/interact.py
@@ -8,13 +8,6 @@ def _get_html(obj):
     """Get the HTML representation of an object"""
     # TODO: use displaypub to make this more general
     ip = get_ipython()
-    rep = ip.display_formatter.formatters['text/html'](obj)
-    
-    if rep is not None:
-        return rep
-    elif hasattr(obj, '_repr_html_'):
-        return obj._repr_html_()
-
     png_rep = ip.display_formatter.formatters['image/png'](obj)
 
     if png_rep is not None:
@@ -24,6 +17,13 @@ def _get_html(obj):
                 'base64,{0}">'.format(png_rep.encode('base64')))
     else:
         return "<p> {0} </p>".format(str(obj))
+
+    rep = ip.display_formatter.formatters['text/html'](obj)
+
+    if rep is not None:
+        return rep
+    elif hasattr(obj, '_repr_html_'):
+        return obj._repr_html_()
 
 
 class StaticInteract(object):


### PR DESCRIPTION
This addresses issue #6 which I also encountered. The problem was that (at least in my version of matplotlib - 1.4.x) `._repr_html_()` is valid for Figure objects, but returns `None`. If there was a reason for trying 'text/html' before 'image/png', then maybe we can just add a special condition to account for this in line 15.

Thanks for writing this package! I'm looking forward to using the heck out of it. I'm gracing it with my very first public PR, too. Also, we met very briefly at SciPy last year. I was working at bitly at the time, but I'd be surprised if you remember me.
